### PR TITLE
For 33453, fixes hanging issue when logging

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -141,28 +141,28 @@ class MaxEngine(sgtk.platform.Engine):
         :param msg: The message string to log
         """
         if self.get_setting("debug_logging", False):
-            self.execute_in_main_thread(self._print_output, "Shotgun Debug: %s" % msg)
+            self.async_execute_in_main_thread(self._print_output, "Shotgun Debug: %s" % msg)
 
     def log_info(self, msg):
         """
         Info logging.
         :param msg: The message string to log
         """
-        self.execute_in_main_thread(self._print_output, "Shotgun Info: %s" % msg)
+        self.async_execute_in_main_thread(self._print_output, "Shotgun Info: %s" % msg)
 
     def log_warning(self, msg):
         """
         Warning logging.
         :param msg: The message string to log
         """
-        self.execute_in_main_thread(self._print_output, "Shotgun Warning: %s" % msg)
+        self.async_execute_in_main_thread(self._print_output, "Shotgun Warning: %s" % msg)
 
     def log_error(self, msg):
         """
         Error logging.
         :param msg: The message string to log
         """
-        self.execute_in_main_thread(self._print_output, "Shotgun Error: %s" % msg)
+        self.async_execute_in_main_thread(self._print_output, "Shotgun Error: %s" % msg)
 
     def _print_output(self, msg):
         """

--- a/info.yml
+++ b/info.yml
@@ -49,4 +49,4 @@ description: "Shotgun Integration in 3ds Max Plus"
 
 # Required minimum versions for this item to run
 requires_shotgun_version:
-requires_core_version: "v0.15.11"
+requires_core_version: "v0.16.35"


### PR DESCRIPTION
Logging is now fired and forgotten to the main thread instead of blocking, which fixes deadlocks when the main thread is waiting for a background thread that is trying to log something.