### PR TITLE
33062 Adds a call to log a user metric for the DCC version

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -57,9 +57,6 @@ class MaxEngine(sgtk.platform.Engine):
             # and log the warning
             self.log_warning(msg)
 
-        self.log_user_attribute_metric("3ds Max Plus version",
-            self._max_version_to_year(self._get_max_version())
-
         elif not self._is_at_least_max_2015():
             # Unsupported max version
             msg = ("Shotgun Pipeline Toolkit!\n\n"
@@ -70,6 +67,13 @@ class MaxEngine(sgtk.platform.Engine):
                            
             # and log the warning
             self.log_warning(msg)
+
+        try:
+            self.log_user_attribute_metric("3ds Max Plus version",
+                self._max_version_to_year(self._get_max_version())
+        except:
+            # ignore all errors. ex: using a core that doesn't support metrics
+            pass
 
         self._safe_dialog = []
 

--- a/engine.py
+++ b/engine.py
@@ -57,6 +57,9 @@ class MaxEngine(sgtk.platform.Engine):
             # and log the warning
             self.log_warning(msg)
 
+        self.log_user_attribute_metric("3ds Max Plus version",
+            self._max_version_to_year(self._get_max_version())
+
         elif not self._is_at_least_max_2015():
             # Unsupported max version
             msg = ("Shotgun Pipeline Toolkit!\n\n"

--- a/info.yml
+++ b/info.yml
@@ -51,4 +51,3 @@ description: "Shotgun Integration in 3ds Max Plus"
 requires_shotgun_version:
 requires_core_version: "v0.16.35"
 
-# XXX will require core version with metrics logging

--- a/info.yml
+++ b/info.yml
@@ -50,3 +50,5 @@ description: "Shotgun Integration in 3ds Max Plus"
 # Required minimum versions for this item to run
 requires_shotgun_version:
 requires_core_version: "v0.16.35"
+
+# XXX will require core version with metrics logging


### PR DESCRIPTION
The call logs the metric internally and ignores any errors. This prevents the need to force the engine's users to update to a new core that supports metrics. When a supported core is updated, the metric will be logged.