### PR TITLE
import QtCore and QtGui from sgtk

### DIFF
--- a/python/tk_3dsmaxplus/menu_generation.py
+++ b/python/tk_3dsmaxplus/menu_generation.py
@@ -15,12 +15,8 @@ import os
 import sys
 import traceback
 
-from PySide import QtGui
-from PySide import QtCore
+from sgtk.platform.qt import QtCore, QtGui
 from .maxscript import MaxScript
-
-import MaxPlus
-import sgtk
 
 class MenuGenerator(object):
     """


### PR DESCRIPTION
Import QtCore and QtGui from sgtk, in order to be compatible with DCCs using PySide2.