### PR TITLE
Improved SSL handling for versions of 3dsmax which come with SSL

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -55,7 +55,7 @@ class MaxEngine(sgtk.platform.Engine):
         if self._get_max_version() > MaxEngine.MAXIMUM_SUPPORTED_VERSION:
             # Untested max version
             msg = ("Shotgun Pipeline Toolkit!\n\n"
-                   "The Shotgun Pipeline Toolkit has not yet been fully tested with 3ds Max versions greater then 2016. "
+                   "The Shotgun Pipeline Toolkit has not yet been fully tested with 3ds Max versions greater than 2017. "
                    "You can continue to use the Toolkit but you may experience bugs or "
                    "instability.  Please report any issues you see to support@shotgunsoftware.com")
             
@@ -352,25 +352,18 @@ class MaxEngine(sgtk.platform.Engine):
         year = 2000 + (math.ceil(version / 1000.0) - 2)
         return year
 
-    def _get_max_release(self, x): 
-        """
-        Macro to get 3ds max release from version id 
-        (not currently present in MaxPlus, but found in max's c++ sdk)
-        :param x: 3ds max Version id
-        """
-        return (((x)>>16)&0xffff)
-
     def _get_max_version(self):
         """
         Returns Version integer of max release number.
         """
         # 3dsMax Version returns a number which contains max version, sdk version, etc...
-        versionId = MaxPlus.Application.Get3DSMAXVersion()
+        version_id = MaxPlus.Application.Get3DSMAXVersion()
         
         # Transform it to a version id
-        version = self._get_max_release(versionId)
+        # (Macro to get 3ds max release from version id)
+        version_number = (version_id >> 16) & 0xffff
 
-        return version
+        return version_number
 
     def _is_at_least_max_2015(self):
         """

--- a/engine.py
+++ b/engine.py
@@ -11,9 +11,7 @@
 A 3ds Max (2015+) engine for Toolkit that uses MaxPlus.
 """
 import os
-import sys
 import time
-import thread
 import math
 
 import sgtk
@@ -54,14 +52,17 @@ class MaxEngine(sgtk.platform.Engine):
 
         if self._get_max_version() > MaxEngine.MAXIMUM_SUPPORTED_VERSION:
             # Untested max version
+
+            highest_supported_version = self._max_version_to_year(MaxEngine.MAXIMUM_SUPPORTED_VERSION)
+
             msg = ("Shotgun Pipeline Toolkit!\n\n"
-                   "The Shotgun Pipeline Toolkit has not yet been fully tested with 3ds Max versions greater than 2017. "
-                   "You can continue to use the Toolkit but you may experience bugs or "
-                   "instability.  Please report any issues you see to support@shotgunsoftware.com")
+                   "The Shotgun Pipeline Toolkit has not yet been fully tested with 3ds Max versions greater than %s. "
+                   "You can continue to use the Toolkit but you may experience bugs or instability. "
+                   "Please report any issues you see to support@shotgunsoftware.com" % highest_supported_version)
             
             # Display warning dialog
             max_year = self._max_version_to_year(self._get_max_version())
-            max_next_year = self._max_version_to_year(MaxEngine.MAXIMUM_SUPPORTED_VERSION) + 1
+            max_next_year = highest_supported_version + 1
             if max_year >= self.get_setting("compatibility_dialog_min_version", max_next_year):
                 MaxPlus.Core.EvalMAXScript('messagebox "Warning - ' + msg + '" title: "Shotgun Warning"')
 
@@ -107,7 +108,7 @@ class MaxEngine(sgtk.platform.Engine):
                     if obj in engine._safe_dialog: 
                         engine._safe_dialog.remove(obj)
 
-                return False;
+                return False
 
         self.dialogEvents = DialogEvents()
 
@@ -342,7 +343,7 @@ class MaxEngine(sgtk.platform.Engine):
     MAX_RELEASE_R17 = 17000
 
     # Latest supported max version
-    MAXIMUM_SUPPORTED_VERSION = 19000
+    MAXIMUM_SUPPORTED_VERSION = 20000
 
     def _max_version_to_year(self, version):
         """ 

--- a/python/startup/bootstrap.py
+++ b/python/startup/bootstrap.py
@@ -14,7 +14,7 @@ import MaxPlus
 
 # the version of max when a working SSL python
 # started to be distributed with it.
-SSL_INCLUDED_VERSION = 19000
+SSL_INCLUDED_VERSION = 20000
 
 def error(msg):
     """

--- a/python/startup/bootstrap.py
+++ b/python/startup/bootstrap.py
@@ -12,6 +12,10 @@ import sys
 
 import MaxPlus
 
+# the version of max when a working SSL python
+# started to be distributed with it.
+SSL_INCLUDED_VERSION = 19000
+
 def error(msg):
     """
     Error Repost
@@ -19,18 +23,26 @@ def error(msg):
     """
     print "ERROR: %s" % msg
 
+
 def bootstrap_sgtk():
     """
     Bootstrap. This is called when preparing to launch by multi-launch.
     """
-    # use _ssl with fix for slowdown
     if sys.platform == "win32":
-        resources = os.path.join(os.path.dirname(__file__), "..", "..", "resources")
-        ssl_path = os.path.join(resources, "ssl_fix")
-        sys.path.insert(0, ssl_path)
-        path_parts = os.environ.get("PYTHONPATH", "").split(";")
-        path_parts = [ssl_path] + path_parts
-        os.environ["PYTHONPATH"] = ";".join(path_parts)
+
+        # get the version id from max
+        version_id = MaxPlus.Application.Get3DSMAXVersion()
+        version_number = (version_id >> 16) & 0xffff
+
+        if version_number < SSL_INCLUDED_VERSION:
+            # our version of 3dsmax does not have ssl included.
+            # patch this up by adding to the pythonpath
+            resources = os.path.join(os.path.dirname(__file__), "..", "..", "resources")
+            ssl_path = os.path.join(resources, "ssl_fix")
+            sys.path.insert(0, ssl_path)
+            path_parts = os.environ.get("PYTHONPATH", "").split(";")
+            path_parts = [ssl_path] + path_parts
+            os.environ["PYTHONPATH"] = ";".join(path_parts)
     else:
         error("Shotgun: Unknown platform - cannot setup ssl")
         return

--- a/python/tk_3dsmaxplus/menu_generation.py
+++ b/python/tk_3dsmaxplus/menu_generation.py
@@ -14,6 +14,7 @@ Menu handling for 3ds Max
 import os
 import sys
 import traceback
+import unicodedata
 
 from sgtk.platform.qt import QtCore, QtGui
 from .maxscript import MaxScript


### PR DESCRIPTION
This change ensures that versions of max which have a working ssl python dll don't get the toolkit engine ssl hotpatch applied. Also bumps the max supported version.