### PR TITLE
Impossible to enter a note in the SG panel activity tab in latest Max version.

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -355,6 +355,10 @@ class MaxEngine(sgtk.platform.Engine):
             dock_widget.setObjectName(dock_widget_id)
             dock_widget.setWidget(widget_instance)
             self.log_debug("Created new dock widget %s" % dock_widget_id)
+
+            # Disable 3dsMax accelerators, in order for QTextEdit and QLineEdit
+            # widgets to work properly.
+            widget_instance.setProperty("NoMaxAccelerators", True)
         else:
             # The dock widget wrapper already exists, so just get the
             # shotgun panel from it.


### PR DESCRIPTION
It's Impossible to enter a note in the SG panel activity tab because accelerators are enabled.  The fix is to set property "NoMaxAccelerators" on the panel parent widget.