### PR TITLE
SG-6429_fix_publish_save_bug

### DIFF
--- a/hooks/tk-multi-publish2/basic/publish_session.py
+++ b/hooks/tk-multi-publish2/basic/publish_session.py
@@ -12,6 +12,7 @@ import os
 import pprint
 import MaxPlus
 import sgtk
+from sgtk.utils.filesystem import ensure_folder_exists
 
 HookBaseClass = sgtk.get_hook_baseclass()
 
@@ -345,6 +346,9 @@ def _save_session(path):
     """
     Save the current session to the supplied path.
     """
+    # max won't ensure that the folder is created when saving, so we must make sure it exists
+    folder = os.path.dirname(path)
+    ensure_folder_exists(folder)
     MaxPlus.FileManager.Save(path)
 
 

--- a/hooks/tk-multi-publish2/basic/publish_session.py
+++ b/hooks/tk-multi-publish2/basic/publish_session.py
@@ -12,7 +12,7 @@ import os
 import pprint
 import MaxPlus
 import sgtk
-from sgtk.utils.filesystem import ensure_folder_exists
+from sgtk.util.filesystem import ensure_folder_exists
 
 HookBaseClass = sgtk.get_hook_baseclass()
 


### PR DESCRIPTION
Fixes an issue where it would error if the workfile save path contained a dynamic folder that needed to be created. Before the fix it wouldn't check to see if the folder for the new file existed before running the 3dsmax save command.

A template like this would cause the issue because the `version` folder wouldn't have been created up front:

```
max_asset_work:
        definition: '@asset_root/work/3dsmax/v{version}/{name}.v{version}.max'
```
