### PR TITLE
SG-12156 fix for getting parent window in 2018 - 2019

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -363,7 +363,7 @@ class MaxEngine(sgtk.platform.Engine):
         # Older versions of Max make use of special logic in _create_dialog
         # to handle window parenting. If we can, though, we should go with
         # the more standard approach to getting the main window.
-        if self._max_version_to_year(self._get_max_version()) > 2019:
+        if self._max_version_to_year(self._get_max_version()) > 2017:
             return MaxPlus.GetQMaxMainWindow()
         else:
             return super(MaxEngine, self)._get_dialog_parent()

--- a/python/startup/bootstrap.py
+++ b/python/startup/bootstrap.py
@@ -60,7 +60,6 @@ def bootstrap_sgtk_classic():
         error("Shotgun: Could not start engine: %s" % e)
         return
 
-
 def bootstrap_sgtk_with_plugins():
     """
     Parse environment variables for a list of plugins to load that will
@@ -115,11 +114,11 @@ def bootstrap_sgtk():
     if file_to_open:
         MaxPlus.FileManager.Open(file_to_open)
 
-    # # clean up temp env vars
-    # for var in ["TANK_ENGINE", "TANK_CONTEXT", "TANK_FILE_TO_OPEN",
-    #             "SGTK_LOAD_MAX_PLUGINS"]:
-    #     if var in os.environ:
-    #         del os.environ[var]
+    # clean up temp env vars
+    for var in ["TANK_ENGINE", "TANK_CONTEXT", "TANK_FILE_TO_OPEN",
+                "SGTK_LOAD_MAX_PLUGINS"]:
+        if var in os.environ:
+            del os.environ[var]
 
 
 bootstrap_sgtk()

--- a/python/startup/bootstrap.py
+++ b/python/startup/bootstrap.py
@@ -120,5 +120,4 @@ def bootstrap_sgtk():
         if var in os.environ:
             del os.environ[var]
 
-
 bootstrap_sgtk()

--- a/python/startup/bootstrap.py
+++ b/python/startup/bootstrap.py
@@ -54,14 +54,7 @@ def bootstrap_sgtk_classic():
         return
 
     try:
-        try:
-            sgtk.platform.start_engine(engine_name, context.tank, context)
-        except:
-            logger.exception("Shotgun: Could not start engine, going to try again")
-            import time
-            time.sleep(2)
-            # wait a short duration and try again
-            sgtk.platform.start_engine(engine_name, context.tank, context)
+        sgtk.platform.start_engine(engine_name, context.tank, context)
     except Exception, e:
         logger.exception("Shotgun: Could not start engine")
         error("Shotgun: Could not start engine: %s" % e)

--- a/python/startup/bootstrap.py
+++ b/python/startup/bootstrap.py
@@ -34,14 +34,14 @@ def bootstrap_sgtk_classic():
     try:
         import sgtk
     except Exception, e:
-        error("Shotgun: Could not import sgtk! Disabling for now: %s" % e)
+        error("Could not import sgtk! Disabling for now: %s" % e)
         return
 
     sgtk.LogManager().initialize_base_file_handler("tk-3dsmaxplus")
     logger = sgtk.LogManager.get_logger(__name__)
 
     if not "TANK_ENGINE" in os.environ:
-        logger.error("Shotgun: Missing required environment variable TANK_ENGINE.")
+        logger.error("Missing required environment variable TANK_ENGINE.")
         error("Shotgun: Missing required environment variable TANK_ENGINE.")
         return
 
@@ -49,14 +49,14 @@ def bootstrap_sgtk_classic():
     try:
         context = sgtk.context.deserialize(os.environ.get("TANK_CONTEXT"))
     except Exception, e:
-        logger.exception("Shotgun: Could not create context! sgtk will be disabled.")
+        logger.exception("Could not create context! sgtk will be disabled.")
         error("Shotgun: Could not create context! sgtk will be disabled. Details: %s" % e)
         return
 
     try:
         sgtk.platform.start_engine(engine_name, context.tank, context)
     except Exception, e:
-        logger.exception("Shotgun: Could not start engine")
+        logger.exception("Could not start engine")
         error("Shotgun: Could not start engine: %s" % e)
         return
 


### PR DESCRIPTION
This contains a fix for parenting to the main 3dsmax window in 2018 (and probably 2019).
The issue was that on occasion the 3dsmax integrations wouldn't start and you would get an error like:
`ERROR: Shotgun: Could not start engine: 'NoneType' object has no attribute 'styleSheet'` to the max script listener.

This error was infrequent, though it seemed that under certain setups or perhaps strain, it could happen more frequently. The fix is to use the window parenting method that was previously used for just Max 2020.

In addition, I've added logging around the Max startup code so that we can get better visibility on errors when bootstrapping.
