### PR TITLE
SG-14612 Fix for scene file not opening on startup

### DIFF
--- a/python/startup/bootstrap.py
+++ b/python/startup/bootstrap.py
@@ -110,12 +110,12 @@ def bootstrap_sgtk():
         bootstrap_sgtk_classic()
 
     # if a file was specified, load it now
-    file_to_open = os.environ.get("TANK_FILE_TO_OPEN")
+    file_to_open = os.environ.get("SGTK_FILE_TO_OPEN")
     if file_to_open:
         MaxPlus.FileManager.Open(file_to_open)
 
     # clean up temp env vars
-    for var in ["TANK_ENGINE", "TANK_CONTEXT", "TANK_FILE_TO_OPEN",
+    for var in ["TANK_ENGINE", "TANK_CONTEXT", "SGTK_FILE_TO_OPEN",
                 "SGTK_LOAD_MAX_PLUGINS"]:
         if var in os.environ:
             del os.environ[var]


### PR DESCRIPTION
It is possible to provide the engine with a scene file to open when bootstrapping.
Currently this functionality is broken, due to the startup code setting `SGTK_FILE_TO_OPEN` and the bootstrap code looking for `TANK_FILE_TO_OPEN`.
This fix updates it to `SGTK_FILE_TO_OPEN` in the bootstrap code.
