### PR TITLE
SG-14434: deprecate the engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+## Deprecation notice
+
+The tk-3dsmaxplus engine has been deprecated. We recommend that you upgrade your configuration to the new [tk-3dsmax](https://github.com/shotgunsoftware/tk-3dsmax) engine. Versions of 3dsMax 2021 and up will only be supported by the new engine.
+
+Visit [this page](https://developer.shotgunsoftware.com/tk-3dsmax) if you want to learn more
+on how to migrate your environment to the new engine.
+
 ## Documentation
 This repository is a part of the Shotgun Pipeline Toolkit.
 

--- a/engine.py
+++ b/engine.py
@@ -229,7 +229,10 @@ class MaxEngine(sgtk.platform.Engine):
         # Run a series of app instance commands at startup.
         self._run_app_instance_commands()
 
-        self.async_execute_in_main_thread(self.tk_3dsmax.show_update_dialog)
+        # The new engine is supported only for Max 2017 and up, so recommend an update
+        # only for those users.
+        if self._max_version_to_year(self._get_max_version()) >= 2017:
+            self.async_execute_in_main_thread(self.tk_3dsmax.show_update_dialog)
 
     def post_context_change(self, old_context, new_context):
         """

--- a/engine.py
+++ b/engine.py
@@ -232,7 +232,22 @@ class MaxEngine(sgtk.platform.Engine):
         # The new engine is supported only for Max 2017 and up, so recommend an update
         # only for those users.
         if self._max_version_to_year(self._get_max_version()) >= 2017:
-            self.async_execute_in_main_thread(self.tk_3dsmax.show_update_dialog)
+            self.async_execute_in_main_thread(self._show_update_dialog)
+
+    def _show_update_dialog(self):
+        """
+        Display the Update Engine dialog.
+        """
+        # We need to keep a ref of the dialog or PySide/Python will garbage collect it before
+        # the user dismisses it.
+        self._update_dialog = self.tk_3dsmax.show_update_dialog(self._get_dialog_parent())
+        self._update_dialog.closing.connect(self._on_update_dialog_closed)
+
+    def _on_update_dialog_closed(self):
+        """
+        Clear reference to dead update dialog.
+        """
+        del self._update_dialog
 
     def post_context_change(self, old_context, new_context):
         """

--- a/engine.py
+++ b/engine.py
@@ -244,12 +244,6 @@ class MaxEngine(sgtk.platform.Engine):
             return
         self.show_dialog("tk-3dsmaxplus deprecation notice", self, self.tk_3dsmax.UpdateEngineDlg)
 
-    def _on_update_dialog_closed(self):
-        """
-        Clear reference to dead update dialog.
-        """
-        del self._update_dialog
-
     def post_context_change(self, old_context, new_context):
         """
         Handles necessary processing after a context change has been completed

--- a/engine.py
+++ b/engine.py
@@ -240,8 +240,9 @@ class MaxEngine(sgtk.platform.Engine):
         """
         # We need to keep a ref of the dialog or PySide/Python will garbage collect it before
         # the user dismisses it.
-        self._update_dialog = self.tk_3dsmax.show_update_dialog(self._get_dialog_parent())
-        self._update_dialog.closing.connect(self._on_update_dialog_closed)
+        if self.tk_3dsmax.UpdateEngineDlg.should_skip_dialog():
+            return
+        self.show_dialog("tk-3dsmaxplus deprecation notice", self, self.tk_3dsmax.UpdateEngineDlg)
 
     def _on_update_dialog_closed(self):
         """

--- a/engine.py
+++ b/engine.py
@@ -229,6 +229,8 @@ class MaxEngine(sgtk.platform.Engine):
         # Run a series of app instance commands at startup.
         self._run_app_instance_commands()
 
+        self.async_execute_in_main_thread(self.tk_3dsmax.show_update_dialog)
+
     def post_context_change(self, old_context, new_context):
         """
         Handles necessary processing after a context change has been completed

--- a/info.yml
+++ b/info.yml
@@ -79,3 +79,5 @@ description: "Shotgun Integration in 3ds Max Plus"
 requires_shotgun_version:
 requires_core_version: "v0.18.45"
 
+frameworks:
+    - {"name": "tk-framework-shotgunutils", "version": "v5.x.x", "minimum_version": "v5.2.2"}

--- a/python/tk_3dsmaxplus/__init__.py
+++ b/python/tk_3dsmaxplus/__init__.py
@@ -10,3 +10,4 @@
 
 from .menu_generation import MenuGenerator
 from .maxscript import MaxScript
+from .update_engine import show_update_dialog

--- a/python/tk_3dsmaxplus/__init__.py
+++ b/python/tk_3dsmaxplus/__init__.py
@@ -10,4 +10,4 @@
 
 from .menu_generation import MenuGenerator
 from .maxscript import MaxScript
-from .update_engine import show_update_dialog
+from .update_engine import UpdateEngineDlg

--- a/python/tk_3dsmaxplus/ui/update_engine.py
+++ b/python/tk_3dsmaxplus/ui/update_engine.py
@@ -47,7 +47,6 @@ class Ui_UpdateEngine(object):
         self.verticalLayout.addLayout(self.horizontalLayout_2)
 
         self.retranslateUi(UpdateEngine)
-        QtCore.QObject.connect(self.ok_button, QtCore.SIGNAL("clicked()"), UpdateEngine.close)
         QtCore.QMetaObject.connectSlotsByName(UpdateEngine)
 
     def retranslateUi(self, UpdateEngine):

--- a/python/tk_3dsmaxplus/ui/update_engine.py
+++ b/python/tk_3dsmaxplus/ui/update_engine.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+
+# Form implementation generated from reading ui file 'update_engine.ui'
+#
+#      by: pyside-uic 0.2.15 running on PySide 1.2.2
+#
+# WARNING! All changes made in this file will be lost!
+
+from sgtk.platform.qt import QtCore, QtGui
+
+class Ui_UpdateEngine(object):
+    def setupUi(self, UpdateEngine):
+        UpdateEngine.setObjectName("UpdateEngine")
+        UpdateEngine.resize(424, 178)
+        self.verticalLayout = QtGui.QVBoxLayout(UpdateEngine)
+        self.verticalLayout.setSpacing(0)
+        self.verticalLayout.setObjectName("verticalLayout")
+        self.message = QtGui.QLabel(UpdateEngine)
+        self.message.setWordWrap(True)
+        self.message.setOpenExternalLinks(True)
+        self.message.setObjectName("message")
+        self.verticalLayout.addWidget(self.message)
+        spacerItem = QtGui.QSpacerItem(20, 40, QtGui.QSizePolicy.Minimum, QtGui.QSizePolicy.Expanding)
+        self.verticalLayout.addItem(spacerItem)
+        self.horizontalLayout = QtGui.QHBoxLayout()
+        self.horizontalLayout.setObjectName("horizontalLayout")
+        self.never_again_checkbox = QtGui.QCheckBox(UpdateEngine)
+        sizePolicy = QtGui.QSizePolicy(QtGui.QSizePolicy.Maximum, QtGui.QSizePolicy.Fixed)
+        sizePolicy.setHorizontalStretch(0)
+        sizePolicy.setVerticalStretch(0)
+        sizePolicy.setHeightForWidth(self.never_again_checkbox.sizePolicy().hasHeightForWidth())
+        self.never_again_checkbox.setSizePolicy(sizePolicy)
+        self.never_again_checkbox.setObjectName("never_again_checkbox")
+        self.horizontalLayout.addWidget(self.never_again_checkbox)
+        self.verticalLayout.addLayout(self.horizontalLayout)
+        self.horizontalLayout_2 = QtGui.QHBoxLayout()
+        self.horizontalLayout_2.setObjectName("horizontalLayout_2")
+        self.ok_button = QtGui.QPushButton(UpdateEngine)
+        sizePolicy = QtGui.QSizePolicy(QtGui.QSizePolicy.Maximum, QtGui.QSizePolicy.Fixed)
+        sizePolicy.setHorizontalStretch(0)
+        sizePolicy.setVerticalStretch(0)
+        sizePolicy.setHeightForWidth(self.ok_button.sizePolicy().hasHeightForWidth())
+        self.ok_button.setSizePolicy(sizePolicy)
+        self.ok_button.setDefault(True)
+        self.ok_button.setObjectName("ok_button")
+        self.horizontalLayout_2.addWidget(self.ok_button)
+        self.verticalLayout.addLayout(self.horizontalLayout_2)
+
+        self.retranslateUi(UpdateEngine)
+        QtCore.QObject.connect(self.ok_button, QtCore.SIGNAL("clicked()"), UpdateEngine.close)
+        QtCore.QMetaObject.connectSlotsByName(UpdateEngine)
+
+    def retranslateUi(self, UpdateEngine):
+        UpdateEngine.setWindowTitle(QtGui.QApplication.translate("UpdateEngine", "tk-3dsmaxplus deprecation warning", None, QtGui.QApplication.UnicodeUTF8))
+        self.message.setText(QtGui.QApplication.translate("UpdateEngine", "<html><head/><body><p>The tk-3dsmaxplus engine has been deprecated. We recommend that you upgrade your configuration to the new <a href=\"https://github.com/shotgunsoftware/tk-3dsmax\"><span style=\" text-decoration: underline; color:#23a5e1;\">tk-3dsmax</span></a> engine. Versions of 3dsMax 2021 and up will only be supported by the new engine.</p><p>Visit <a href=\"https://developer.shotgunsoftware.com/tk-3dsmax\"><span style=\" text-decoration: underline; color:#23a5e1;\">this page</span></a> if you want to learn more on how to migrate your environment to the new engine.</p></body></html>", None, QtGui.QApplication.UnicodeUTF8))
+        self.never_again_checkbox.setText(QtGui.QApplication.translate("UpdateEngine", "Do not show this again.", None, QtGui.QApplication.UnicodeUTF8))
+        self.ok_button.setText(QtGui.QApplication.translate("UpdateEngine", "OK", None, QtGui.QApplication.UnicodeUTF8))
+

--- a/python/tk_3dsmaxplus/update_engine.py
+++ b/python/tk_3dsmaxplus/update_engine.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2019 Shotgun Software Inc.
+# 
+# CONFIDENTIAL AND PROPRIETARY
+# 
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your 
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+"""
+Displays a message inviting the user to switch their Max engine to tk-3dsmax.
+"""
+
+import contextlib
+import os
+
+try:
+    from sgtk.platform.qt import QtCore, QtGui
+    import sgtk
+
+    settings = sgtk.platform.import_framework("tk-framework-shotgunutils", "settings")
+
+    def _should_skip_dialog():
+        settings_manager = settings.UserSettings(sgtk.platform.current_bundle())
+        skip_dialog = settings_manager.retrieve("skip_update_engine_dialog", False)
+        return skip_dialog
+
+    def _skip_dialog():
+        settings_manager = settings.UserSettings(sgtk.platform.current_bundle())
+        settings_manager.store("skip_update_engine_dialog", True)
+
+except Exception:
+    from PySide2 import QtCore, QtWidgets as QtGui
+
+    def _should_skip_dialog():
+        return False
+
+    def _skip_dialog():
+        pass
+
+
+try:
+    from PySide2.QtUiTools import QUiLoader
+except ImportError:
+    from PySide.QtUiTools import QUiLoader
+
+def _show_dialog():
+    resource = os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "..",
+        "resources",
+        "update_engine.ui"
+    )
+    with contextlib.closing(QtCore.QFile(resource)) as resource_file:
+        loader = QUiLoader()
+        dialog = loader.load(resource_file)
+
+    checkbox = dialog.findChild(QtGui.QCheckBox, "never_again_checkbox")
+
+    dialog.exec_()
+
+    return checkbox.isChecked()
+
+
+def show_update_dialog():
+
+    if _should_skip_dialog():
+        return
+
+    skip_dialog_on_next_startup = _show_dialog()
+
+    if skip_dialog_on_next_startup:
+        _skip_dialog()
+
+
+if __name__ == "__main__":
+    if QtGui.QApplication.instance() is None:
+        QtGui.QApplication([])
+    show_update_dialog()

--- a/python/tk_3dsmaxplus/update_engine.py
+++ b/python/tk_3dsmaxplus/update_engine.py
@@ -1,11 +1,11 @@
 # Copyright (c) 2019 Shotgun Software Inc.
-# 
+#
 # CONFIDENTIAL AND PROPRIETARY
-# 
-# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
 # Source Code License included in this distribution package. See LICENSE.
-# By accessing, using, copying or modifying this work you indicate your 
-# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 """
@@ -15,43 +15,60 @@ Displays a message inviting the user to switch their Max engine to tk-3dsmax.
 import contextlib
 import os
 
+# Try to import QtCore and QtGui. If it doesn't work, this means we're not
+# inside 3dsmax and just trying out the GUI from a console.
 try:
     from sgtk.platform.qt import QtCore, QtGui
+    from sgtk.platform.qt5.QtUiTools import QUiLoader
+
+except Exception:
+    from PySide2 import QtCore, QtWidgets as QtGui
+    from PySide2.QtUiTools import QUiLoader
+
+    def _should_skip_dialog():
+        """
+        For testing, the dialog should always be shown.
+        """
+        return False
+
+    def _skip_dialog():
+        """
+        For testing, nothing to do here.
+        """
+        pass
+
+
+else:
     import sgtk
 
     settings = sgtk.platform.import_framework("tk-framework-shotgunutils", "settings")
 
     def _should_skip_dialog():
+        """
+        :returns: ``True`` if the user dismissed the dialog with "Do not show this again"
+            checked in the past, ``False`` otherwise.
+        """
         settings_manager = settings.UserSettings(sgtk.platform.current_bundle())
         skip_dialog = settings_manager.retrieve("skip_update_engine_dialog", False)
         return skip_dialog
 
     def _skip_dialog():
+        """
+        Update user settings so that the dialog is never shown again.
+        """
         settings_manager = settings.UserSettings(sgtk.platform.current_bundle())
         settings_manager.store("skip_update_engine_dialog", True)
 
-except Exception:
-    from PySide2 import QtCore, QtWidgets as QtGui
-
-    def _should_skip_dialog():
-        return False
-
-    def _skip_dialog():
-        pass
-
-
-try:
-    from PySide2.QtUiTools import QUiLoader
-except ImportError:
-    from PySide.QtUiTools import QUiLoader
 
 def _show_dialog():
+    """
+    Show the dialog warning the user about the deprecation.
+
+    :returns: ``True`` if the user requested the dialog to never be shown
+        again, ``False`` otherwise.
+    """
     resource = os.path.join(
-        os.path.dirname(__file__),
-        "..",
-        "..",
-        "resources",
-        "update_engine.ui"
+        os.path.dirname(__file__), "..", "..", "resources", "update_engine.ui"
     )
     with contextlib.closing(QtCore.QFile(resource)) as resource_file:
         loader = QUiLoader()
@@ -65,6 +82,12 @@ def _show_dialog():
 
 
 def show_update_dialog():
+    """
+    Show the update warning dialog.
+
+    If the user checked "Do not show this dialog again." in the past,
+    the method will do nothing.
+    """
 
     if _should_skip_dialog():
         return
@@ -76,6 +99,7 @@ def show_update_dialog():
 
 
 if __name__ == "__main__":
+    # This is for testing from the command line.
     if QtGui.QApplication.instance() is None:
         QtGui.QApplication([])
     show_update_dialog()

--- a/python/tk_3dsmaxplus/update_engine.py
+++ b/python/tk_3dsmaxplus/update_engine.py
@@ -36,6 +36,9 @@ class UpdateEngineDlg(QtGui.QDialog):
         return settings_manager.retrieve("skip_update_engine_dialog", False)
 
     def __init__(self, parent=None):
+        """
+        Init.
+        """
         super(UpdateEngineDlg, self).__init__(parent)
         self._ui = Ui_UpdateEngine()
         self._ui.setupUi(self)

--- a/python/tk_3dsmaxplus/update_engine.py
+++ b/python/tk_3dsmaxplus/update_engine.py
@@ -13,7 +13,6 @@ Displays a message inviting the user to switch their Max engine to tk-3dsmax.
 """
 
 import sgtk
-from sgtk.platform.qt import QtCore, QtGui
 from .ui.update_engine import Ui_UpdateEngine
 
 settings = sgtk.platform.import_framework("tk-framework-shotgunutils", "settings")

--- a/python/tk_3dsmaxplus/update_engine.py
+++ b/python/tk_3dsmaxplus/update_engine.py
@@ -13,6 +13,7 @@ Displays a message inviting the user to switch their Max engine to tk-3dsmax.
 """
 
 import sgtk
+from sgtk.platform.qt import QtCore, QtGui
 from .ui.update_engine import Ui_UpdateEngine
 
 settings = sgtk.platform.import_framework("tk-framework-shotgunutils", "settings")

--- a/python/tk_3dsmaxplus/update_engine.py
+++ b/python/tk_3dsmaxplus/update_engine.py
@@ -24,8 +24,16 @@ class UpdateEngineDlg(QtGui.QDialog):
     The Update Engine dialog. It displays a deprecation message with a checkbox to
     choose not to see this message ever again.
     """
+    hide_tk_title_bar = True
 
-    closing = QtCore.Signal()
+    @classmethod
+    def should_skip_dialog(cls):
+        """
+        :returns: ``True`` if the user dismissed the dialog with "Do not show this again"
+            checked in the past, ``False`` otherwise.
+        """
+        settings_manager = settings.UserSettings(sgtk.platform.current_bundle())
+        return settings_manager.retrieve("skip_update_engine_dialog", False)
 
     def __init__(self, parent=None):
         super(UpdateEngineDlg, self).__init__(parent)
@@ -38,45 +46,19 @@ class UpdateEngineDlg(QtGui.QDialog):
         Dismiss the dialog and records the state of the checkbox if clicked.
         """
         if self._ui.never_again_checkbox.isChecked():
-            _skip_dialog()
-        self.closing.emit()
+            self._skip_dialog()
         self.close()
 
-
-def _should_skip_dialog():
-    """
-    :returns: ``True`` if the user dismissed the dialog with "Do not show this again"
-        checked in the past, ``False`` otherwise.
-    """
-    settings_manager = settings.UserSettings(sgtk.platform.current_bundle())
-    skip_dialog = settings_manager.retrieve("skip_update_engine_dialog", False)
-    return skip_dialog
+    def _skip_dialog(self):
+        """
+        Update user settings so that the dialog is never shown again.
+        """
+        settings_manager = settings.UserSettings(sgtk.platform.current_bundle())
+        settings_manager.store("skip_update_engine_dialog", True)
 
 
-def _show_dialog(parent):
-    """
-    Show the dialog warning the user about the deprecation.
-
-    :returns: ``True`` if the user requested the dialog to never be shown
-        again, ``False`` otherwise.
-    """
-    dialog = UpdateEngineDlg(parent)
-    dialog.show()
-    dialog.raise_()
-    dialog.activateWindow()
-
-    return dialog
 
 
-def show_update_dialog(parent):
-    """
-    Show the update warning dialog.
 
-    If the user checked "Do not show this dialog again." in the past,
-    the method will do nothing.
-    """
 
-    if _should_skip_dialog():
-        return
 
-    return _show_dialog(parent)

--- a/resources/build_resources.sh
+++ b/resources/build_resources.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2018 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+# The path to output all built .py files to:
+UI_PYTHON_PATH=../python/tk_3dsmaxplus/ui
+
+# Helper functions to build UI files
+function build_qt {
+    echo " > Building " $2
+
+    # compile ui to python
+    $1 $2 > $UI_PYTHON_PATH/$3.py
+
+    # replace PySide imports with sgtk.platform.qt and remove line containing Created by date
+    sed -i "" -e "s/from PySide import/from sgtk.platform.qt import/g" -e "/# Created:/d" $UI_PYTHON_PATH/$3.py
+}
+
+function build_ui {
+    build_qt "pyside-uic --from-imports" "$1.ui" "$1"
+}
+
+function build_res {
+    build_qt "pyside-rcc" "$1.qrc" "$1_rc"
+}
+
+
+# build UI's:
+echo "building user interfaces..."
+build_ui update_engine

--- a/resources/update_engine.ui
+++ b/resources/update_engine.ui
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>UpdateEngineBox</class>
- <widget class="QDialog" name="UpdateEngineBox">
+ <class>UpdateEngine</class>
+ <widget class="QWidget" name="UpdateEngine">
   <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>486</width>
-    <height>179</height>
+    <width>424</width>
+    <height>178</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -15,10 +15,7 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <property name="spacing">
-    <number>5</number>
-   </property>
-   <property name="margin">
-    <number>12</number>
+    <number>0</number>
    </property>
    <item>
     <widget class="QLabel" name="message">
@@ -33,34 +30,55 @@
      </property>
     </widget>
    </item>
-   <item alignment="Qt::AlignHCenter">
-    <widget class="QCheckBox" name="never_again_checkbox">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
      </property>
-     <property name="text">
-      <string>Do not show this again.</string>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
      </property>
-    </widget>
+    </spacer>
    </item>
-   <item alignment="Qt::AlignHCenter">
-    <widget class="QPushButton" name="ok_button">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>OK</string>
-     </property>
-     <property name="default">
-      <bool>true</bool>
-     </property>
-    </widget>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QCheckBox" name="never_again_checkbox">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Do not show this again.</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <widget class="QPushButton" name="ok_button">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>OK</string>
+       </property>
+       <property name="default">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>
@@ -69,16 +87,16 @@
   <connection>
    <sender>ok_button</sender>
    <signal>clicked()</signal>
-   <receiver>UpdateEngineBox</receiver>
+   <receiver>UpdateEngine</receiver>
    <slot>close()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>210</x>
-     <y>348</y>
+     <x>211</x>
+     <y>149</y>
     </hint>
     <hint type="destinationlabel">
-     <x>210</x>
-     <y>184</y>
+     <x>211</x>
+     <y>88</y>
     </hint>
    </hints>
   </connection>

--- a/resources/update_engine.ui
+++ b/resources/update_engine.ui
@@ -23,7 +23,7 @@
    <item>
     <widget class="QLabel" name="message">
      <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The tk-3dsmaxplus engine has been deprecated. We recommend that you upgrade your configuration to the new &lt;a href=&quot;https://github.com/shotgunsoftware/tk-3dsmax&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#23a5e1;&quot;&gt;tk-3dsmax&lt;/span&gt;&lt;/a&gt; engine. Versions of 3dsMax 2021 and up will only be supported by the new engine.&lt;/p&gt;&lt;p&gt;Visit this &lt;a href=&quot;http://developer.shotgunsoftware.com/tk-3dsmax&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#23a5e1;&quot;&gt;page&lt;/span&gt;&lt;/a&gt; if you want to learn more on how to migrate your environment to the new engine.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The tk-3dsmaxplus engine has been deprecated. We recommend that you upgrade your configuration to the new &lt;a href=&quot;https://github.com/shotgunsoftware/tk-3dsmax&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#23a5e1;&quot;&gt;tk-3dsmax&lt;/span&gt;&lt;/a&gt; engine. Versions of 3dsMax 2021 and up will only be supported by the new engine.&lt;/p&gt;&lt;p&gt;Visit &lt;a href=&quot;https://developer.shotgunsoftware.com/tk-3dsmax&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#23a5e1;&quot;&gt;this page&lt;/span&gt;&lt;/a&gt; if you want to learn more on how to migrate your environment to the new engine.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>

--- a/resources/update_engine.ui
+++ b/resources/update_engine.ui
@@ -23,7 +23,7 @@
    <item>
     <widget class="QLabel" name="message">
      <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The tk-3dsmaxplus engine has been deprecated. We recommend that you upgrade your configuration to the new &lt;a href=&quot;https://github.com/shotgunsoftware/tk-3dsmax&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#23a5e1;&quot;&gt;tk-3dsmax&lt;/span&gt;&lt;/a&gt; engine.&lt;/p&gt;&lt;p&gt;Visit this &lt;a href=&quot;http://developer.shotgunsoftware.com/tk-3dsmax&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#23a5e1;&quot;&gt;page&lt;/span&gt;&lt;/a&gt; if you want to learn more on how to migrate your environment to the new engine.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The tk-3dsmaxplus engine has been deprecated. We recommend that you upgrade your configuration to the new &lt;a href=&quot;https://github.com/shotgunsoftware/tk-3dsmax&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#23a5e1;&quot;&gt;tk-3dsmax&lt;/span&gt;&lt;/a&gt; engine. Versions of 3dsMax 2021 and up will only be supported by the new engine.&lt;/p&gt;&lt;p&gt;Visit this &lt;a href=&quot;http://developer.shotgunsoftware.com/tk-3dsmax&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#23a5e1;&quot;&gt;page&lt;/span&gt;&lt;/a&gt; if you want to learn more on how to migrate your environment to the new engine.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>

--- a/resources/update_engine.ui
+++ b/resources/update_engine.ui
@@ -83,22 +83,5 @@
   </layout>
  </widget>
  <resources/>
- <connections>
-  <connection>
-   <sender>ok_button</sender>
-   <signal>clicked()</signal>
-   <receiver>UpdateEngine</receiver>
-   <slot>close()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>211</x>
-     <y>149</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>211</x>
-     <y>88</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>

--- a/resources/update_engine.ui
+++ b/resources/update_engine.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>489</width>
-    <height>148</height>
+    <width>486</width>
+    <height>179</height>
    </rect>
   </property>
   <property name="windowTitle">

--- a/resources/update_engine.ui
+++ b/resources/update_engine.ui
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>UpdateEngineBox</class>
+ <widget class="QDialog" name="UpdateEngineBox">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>489</width>
+    <height>148</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>tk-3dsmaxplus deprecation warning</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="spacing">
+    <number>5</number>
+   </property>
+   <property name="margin">
+    <number>12</number>
+   </property>
+   <item>
+    <widget class="QLabel" name="message">
+     <property name="text">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The tk-3dsmaxplus engine has been deprecated. We recommend that you upgrade your configuration to the new &lt;a href=&quot;https://github.com/shotgunsoftware/tk-3dsmax&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#23a5e1;&quot;&gt;tk-3dsmax&lt;/span&gt;&lt;/a&gt; engine.&lt;/p&gt;&lt;p&gt;Visit this &lt;a href=&quot;http://developer.shotgunsoftware.com/tk-3dsmax&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#23a5e1;&quot;&gt;page&lt;/span&gt;&lt;/a&gt; if you want to learn more on how to migrate your environment to the new engine.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+     <property name="openExternalLinks">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item alignment="Qt::AlignHCenter">
+    <widget class="QCheckBox" name="never_again_checkbox">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Do not show this again.</string>
+     </property>
+    </widget>
+   </item>
+   <item alignment="Qt::AlignHCenter">
+    <widget class="QPushButton" name="ok_button">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>OK</string>
+     </property>
+     <property name="default">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>ok_button</sender>
+   <signal>clicked()</signal>
+   <receiver>UpdateEngineBox</receiver>
+   <slot>close()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>210</x>
+     <y>348</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>210</x>
+     <y>184</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/startup.py
+++ b/startup.py
@@ -23,6 +23,29 @@ class MaxLauncher(SoftwareLauncher):
     of 3dsMax.
     """
 
+    def _is_supported(self, sw_version):
+        """
+        Indicate if the version of 3dsmax is supported. In additional
+        to the usual validation that the base class provides,
+        the method makes sure that versions greater than 2020 are
+        not supported.
+        """
+        # First check the default implementation.
+        supported, reason = super(MaxLauncher, self)._is_supported(sw_version)
+        if not supported:
+            return (supported, reason)
+
+        # We don't know which version this is, let it through.
+        if sw_version.version is None:
+            return (True, "")
+
+        # The maxplus engine only supports Max 2020 and down.
+        # Clients who wish to use 2021 must switch to tk-3dsmax.
+        if int(sw_version.version) <= 2020:
+            return (True, "")
+        else:
+            return (False, "The tk-3dsmaxplus engine only supports versions 2020 and older.")
+
     @property
     def minimum_supported_version(self):
         """


### PR DESCRIPTION
When a user updates to the latest version of the engine, they will be greeted with a message saying that they should switch to our fantabulous new `tk-3dsmax` engine. Also, Max 2021+ will not show up.

Here's what the message box looks like.

![image](https://user-images.githubusercontent.com/8126447/70271863-3ec60a00-1775-11ea-8ad5-16ee14396f80.png)

When the user clicks on the first link, they are taken to the repository of the new engine. On the second link, they are taken to the migration documentation.